### PR TITLE
Add attribute start_datetime to Changeish object

### DIFF
--- a/zuul/model.py
+++ b/zuul/model.py
@@ -814,6 +814,8 @@ class Changeish(object):
 
     def __init__(self, project):
         self.project = project
+        self.start_datetime = time.strftime("%Y-%m-%d %H:%M:%S UTC",
+                                            time.gmtime())
 
     def getBasePath(self):
         base_path = ''


### PR DESCRIPTION
Add attribute start_datetime to Changeish object so it
will be possible for email messages triggered off of a timer
to have a unique subject line. Currently the only variable
available is {change.project} which is not enough to generate
a unique subject.

Closes Zuul bug 1359529 https://bugs.launchpad.net/zuul/+bug/1359529
